### PR TITLE
Use expectRegex to synchronize the receives

### DIFF
--- a/SampleScripts/SSH/LinuxApplicationTextConfig.json
+++ b/SampleScripts/SSH/LinuxApplicationTextConfig.json
@@ -69,6 +69,7 @@
     ],
     "Do": [
       { "Function": { "Name": "LoginSsh", "ResultVariable": "LoginResult", "Parameters": [ "%FuncUserName%", "%FuncPassword%", "%UserKey::$%" ] } },
+      { "Function": { "Name": "SetUpEnvironment", "ResultVariable": "ValidateResult" } },
       { "Function": { "Name": "ChangeApplicationPassword", "ResultVariable": "ChangeApplicationPasswordResult",  "Parameters": [ "%ApplicationFilePath%", "%ApplicationFileName%", "%ApplicationPasswordPrefix%"]} },
       { "Function": { "Name": "LogoutSsh", "ResultVariable": "LogoutResult" } },
       { "Return": { "Value": "%ChangeApplicationPasswordResult%" } }
@@ -142,7 +143,7 @@
   "SetUpEnvironment": {
     "Do": [
       { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "unset TERM; stty -echo; LANG=C; LC_ALL=C; SUDO_PROMPT='SUDO password for %p:'; export LANG LC_ALL SUDO_PROMPT; echo \"INIT_CHECK=$?\"" } },
-      { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "FlushBuffer" } },
+      { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "FlushBuffer", "ExpectRegex":"INIT_CHECK=0" } },
       { "Return": { "Value": true } }
     ]
   },
@@ -294,58 +295,16 @@
 	  { "Status": { "Type": "Changing", "Percent": 50,
           "Message": { "Name": "ChangingPassword", "Parameters": [ "%FilePath%, %FileName%, %PasswordPrefix%" ] } }
       },
+	  {  "SetItem": {    "Name": "ExpectResponse", "Value": "(CHGPASS=)|([pP]assword)" } },
 	  {  "Log": {    "Text": "Sending ChangeApplicationPassword Command: \"%DelegationPrefix% -- sh -c 'sed \"s/%PasswordPrefix%.*/%PasswordPrefix%**secret**/g\" \"%FilePath%%FileName%\" > \"%FilePath%%FileName%.new\" && mv \"%FilePath%%FileName%.new\" \"%FilePath%%FileName%\"'; echo \"CHGPASS=$?\"\""  } },
 	  { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "%DelegationPrefix% -- sh -c 'sed \"s/%PasswordPrefix%.*/%PasswordPrefix%%NewPassword%/g\" \"%FilePath%%FileName%\" > \"%FilePath%%FileName%.new\" && mv \"%FilePath%%FileName%.new\" \"%FilePath%%FileName%\"'; echo \"CHGPASS=$?\"", "ContainsSecret": true } },
-	  { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt", "ContainsSecret": true } },
-	  {  "Log": {    "Text": "Waiting for password prompt..."  } },
-	  { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt" } },
-      {  "Log": {    "Text": "Received: %PasswdAttempt%"  } },
-	  { "Condition": {
-                    "If": "Regex.IsMatch(PasswdAttempt, @\"Password\")",
-                    "Then": {
-                      "Do": [
-                        { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "%FuncPassword%", "ContainsSecret": true } },
-                        { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt" } }
-                      ]
-                    }
-                  }
-      },
+	  { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt", "ExpectRegex":"%ExpectResponse%" } },
 	  { "Condition": {
                     "If": "Regex.IsMatch(PasswdAttempt, @\"SUDO password for\")",
                     "Then": {
                       "Do": [
                         { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "%FuncPassword%", "ContainsSecret": true } },
-                        { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt" } }
-                      ]
-                    }
-                  }
-      },
-      { "Condition": {
-                    "If": "Regex.IsMatch(PasswdAttempt, @\"[cC]urrent.*[Pp]assword\")",
-                    "Then": {
-                      "Do": [
-                        { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "%AccountPassword%", "ContainsSecret": true } },
-                        { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt" } }
-                      ]
-                    }
-                  }
-      },
-      { "Condition": {
-                    "If": "Regex.IsMatch(PasswdAttempt, @\".*[Nn]ew.*[Pp]assword:\")",
-                    "Then": {
-                      "Do": [
-                        { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "%NewPassword%", "ContainsSecret": true } },
-                        { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt" } }
-                      ]
-                    }
-                  }
-      },
-      { "Condition": {
-                    "If": "Regex.IsMatch(PasswdAttempt, @\".*[Nn]ew.*[Pp]assword:\")",
-                    "Then": {
-                      "Do": [
-                        { "Send": { "ConnectionObjectName": "ConnectSsh", "Buffer": "%NewPassword%", "ContainsSecret": true } },
-                        { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt" } }
+                        { "Receive": { "ConnectionObjectName": "ConnectSsh", "BufferName": "PasswdAttempt", "ExpectRegex":"%ExpectResponse%" } }
                       ]
                     }
                   }


### PR DESCRIPTION
Address issue https://github.com/OneIdentity/SafeguardCustomPlatform/issues/42

The Receive component reads the next chunk of data from the remote SSH session, but exactly how much data it gets may vary depending on what the remote session is doing at the time, how much output it produces and how quickly the shell session reports the stdout.

As a result, it may take 1 or more Receives to get all the output expected from the commands used in this script to edit the password file.

In this context, it is best to wait until the script has received all the output expected from a command, before continuing with the next step in the script.

The ExpectRegex property of the Receive component can be used to tell the script to keep receiving until the expected regex is received (or Timeout seconds expire).

The ChangePassword should also run the SetUpEnvironment function. This function disables shell echo so that the script doesnt have to handle each line of stdin being echoed to stdout.  It also sets the value of the sudo prompt string in the shell session, so that the script can reliably detect and respond to a sudo password prompt.

