### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require review from SafeguardPasswords team for all changes
+* @OneIdentity/SafeguardPasswords
+


### PR DESCRIPTION
Add CODEOWNERS file requiring SafeguardPasswords team review for all changes.

This is part of the repo modernization effort. The branch rename (master → main) will follow after this merges.