### PR TITLE
Docs/schema cleanup for CreateAdminUser removal (#72) and AWS/Twitter/Facebook deprecation (#78)

### DIFF
--- a/docs/agent-reference/rsms-engine-map.md
+++ b/docs/agent-reference/rsms-engine-map.md
@@ -173,13 +173,13 @@ feature flags** toggling operations — support is per-platform-definition.
 
 Operations the engine actually **implements** (`[ScriptableOperation]` methods in
 `ScriptableModule.cs`): `CheckSystem:112`, `CheckPassword:181`,
-`ChangePassword:227`, `ChangeSshKey:303`,
-`CheckApiKey:326`, `ChangeApiKey:349`, `UpdateDependentSystem:372`,
-`DiscoverAccounts:520`, `DiscoverServices:558`, `DiscoverSshHostKey:602`,
-`EnableAccount:634`, `DisableAccount:672`, `DemoteAccount:710`,
-`ElevateAccount:737`, `DiscoverAuthorizedKeys:764`, `CheckSshKey:810`,
-`DiscoverAssets:861`, `RemoveAuthorizedKey:924`, `CheckFile:971`,
-`ChangeFile:1022`, `RetrieveSshHostKey:1080`.
+`ChangePassword:227`, `ChangeSshKey:264`,
+`CheckApiKey:287`, `ChangeApiKey:310`, `UpdateDependentSystem:333`,
+`DiscoverAccounts:481`, `DiscoverServices:519`, `DiscoverSshHostKey:563`,
+`EnableAccount:595`, `DisableAccount:633`, `DemoteAccount:671`,
+`ElevateAccount:698`, `DiscoverAuthorizedKeys:725`, `CheckSshKey:771`,
+`DiscoverAssets:822`, `RemoveAuthorizedKey:885`, `CheckFile:932`,
+`ChangeFile:983`, `RetrieveSshHostKey:1041`.
 
 > **Compatibility gap:** `OperationType` defines `DiscoverApiKeys` and
 > `CheckHostKey`, but neither has a `[ScriptableOperation]` method in

--- a/docs/agent-reference/rsms-engine-map.md
+++ b/docs/agent-reference/rsms-engine-map.md
@@ -161,7 +161,7 @@ Public operation names are the `Rsms.Public.Definitions.OperationType` enum —
 UpdateDependentSystem, DiscoverAccounts, DiscoverServices, DiscoverSshHostKey,
 EnableAccount, DisableAccount, DiscoverAuthorizedKeys, CheckSshKey, CheckHostKey,
 DiscoverAssets, RemoveAuthorizedKey, RetrieveSshHostKey, CheckApiKey,
-ChangeApiKey, DiscoverApiKeys, CreateAdminUser, ElevateAccount, DemoteAccount,
+ChangeApiKey, DiscoverApiKeys, ElevateAccount, DemoteAccount,
 CheckFile, ChangeFile`
 
 A script "supports" an operation iff its `Functions` contains a function whose
@@ -173,7 +173,7 @@ feature flags** toggling operations — support is per-platform-definition.
 
 Operations the engine actually **implements** (`[ScriptableOperation]` methods in
 `ScriptableModule.cs`): `CheckSystem:112`, `CheckPassword:181`,
-`ChangePassword:227`, `CreateAdminUser:264`, `ChangeSshKey:303`,
+`ChangePassword:227`, `ChangeSshKey:303`,
 `CheckApiKey:326`, `ChangeApiKey:349`, `UpdateDependentSystem:372`,
 `DiscoverAccounts:520`, `DiscoverServices:558`, `DiscoverSshHostKey:602`,
 `EnableAccount:634`, `DisableAccount:672`, `DemoteAccount:710`,

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -54,7 +54,6 @@ The following operation categories are available for custom platforms. Detailed 
 | Dependencies | `UpdateDependentSystem` |
 | API Keys | `CheckApiKey`, `ChangeApiKey` |
 | Files | `CheckFile`, `ChangeFile` |
-| Admin | `CreateAdminUser` |
 
 > [!NOTE]
 > `RetrieveSshHostKey` and `CheckHostKey` are not supported for custom platforms.

--- a/docs/reference/commands/cookies.md
+++ b/docs/reference/commands/cookies.md
@@ -121,7 +121,7 @@ Expires one or more cookies in the shared cookie jar.
 
 ### Seed cookies before a console login flow
 
-From the built-in `System/Aws.json` platform definition:
+From the (now-deprecated) built-in `System/Aws.json` platform definition. The AWS built-in platform is deprecated — this is shown only to illustrate the `SetCookie` syntax:
 
 ```json
 {

--- a/docs/reference/commands/forms.md
+++ b/docs/reference/commands/forms.md
@@ -142,7 +142,7 @@ From `samples/http/twitter/CustomTwitter.json`:
 
 ### The alias form shown in older scripts
 
-From the built-in `System/Twitter.json` platform definition:
+From the (now-deprecated) built-in `System/Twitter.json` platform definition. The Twitter built-in platform is deprecated — this is shown only to illustrate the `SetFormData` alias syntax:
 
 ```json
 {

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -6,7 +6,7 @@ Operations are the named entry points in a custom platform script that SPP invok
 
 This page documents the operations available for custom platform scripts.
 
-> **Note:** Some operations defined in the operation type system (`DiscoverApiKeys`, `CheckHostKey`, `CreateAdminUser`) are not yet available for custom platforms. See the [GitHub issues](https://github.com/OneIdentity/SafeguardCustomPlatform/issues) for tracking.
+> **Note:** Some operations defined in the operation type system (`DiscoverApiKeys`, `CheckHostKey`) are not yet available for custom platforms. See the [GitHub issues](https://github.com/OneIdentity/SafeguardCustomPlatform/issues) for tracking.
 
 ## Quick Reference
 

--- a/docs/reference/reserved-parameters.md
+++ b/docs/reference/reserved-parameters.md
@@ -112,11 +112,14 @@ These reserved names extend the service-account connection context beyond userna
 | `FuncAccountDn` | String | `Asset.ServiceAccount.DistinguishedName` | Service account directory identity |
 | `FuncUserDomain` | String | `Asset.ServiceAccount.Domain` | Domain-backed service account |
 | `FuncUserNetBiosName` | String | `Asset.ServiceAccount.NetBiosName` | NetBIOS domain for the service account |
-| `FuncUserAccessKeyId` | String | `Asset.AccessKeyId` | Access Key ID field that appears when the script declares it |
-| `FuncUserAccessKey` | Secret | `Asset.SecretKey` | Access Key Secret field that appears alongside the ID |
+| `FuncUserAccessKeyId` | String | `Asset.AccessKeyId` | Access Key ID field that appears when the script declares it. **Deprecated** — see note below. |
+| `FuncUserAccessKey` | Secret | `Asset.SecretKey` | Access Key Secret field that appears alongside the ID. **Deprecated** — see note below. |
 | `UserKey` | Secret | Service-account private SSH key | Service account SSH key assigned in SPP |
 | `Instance` | String | `Asset.Instance` | Instance field that appears when the script declares it |
 | `SshPort` | Integer | `Platform.SessionSshPort` | Platform-level SSH session port or script default |
+
+> [!NOTE]
+> `FuncUserAccessKeyId` / `FuncUserAccessKey` surface the asset's `AccessKeyId` and `SecretKey` connection properties, which back the **AccessKey** service-account credential type. Those properties are **deprecated** and retained only for backward compatibility — new platforms should not rely on them. Use a managed-account credential type appropriate to the target instead.
 
 ### Connection, TLS, and Proxy Settings
 

--- a/schema/custom-platform-script.schema.json
+++ b/schema/custom-platform-script.schema.json
@@ -140,10 +140,6 @@
     "RemoveAuthorizedKey": {
       "$ref": "#/definitions/operationDefinition",
       "description": "Removes an authorized SSH key from the target."
-    },
-    "CreateAdminUser": {
-      "$ref": "#/definitions/operationDefinition",
-      "description": "Creates an administrative user on the target."
     }
   },
   "required": [


### PR DESCRIPTION
Companion documentation/schema changes for two PangaeaAppliance engine PRs.

## #72 — Remove dead `CreateAdminUser` operation references
`CreateAdminUser` was built for the discontinued, never-released **PamEssentials** product (which reused the Hercules/Rsms engine). It is not exposed in the SPP public API and is being removed from the engine in [PangaeaAppliance#210](https://github.com/Kevin-Andrew/PangaeaAppliance/pull/210). Removed it from the author-facing surfaces here:

- `schema/custom-platform-script.schema.json` — dropped the `CreateAdminUser` operation definition
- `docs/concepts/architecture.md` — dropped the `Admin / CreateAdminUser` capability row
- `docs/reference/operations.md` — dropped `CreateAdminUser` from the "not yet available" note (kept `DiscoverApiKeys`, `CheckHostKey`)
- `docs/agent-reference/rsms-engine-map.md` — removed `CreateAdminUser` from the enum-order and implemented-operations lists, and **refreshed all `ScriptableModule.cs` line numbers** that shifted once the handler was removed (e.g. `ChangeSshKey 303→264`, `RetrieveSshHostKey 1080→1041`)

## #78 — Note deprecation of AccessKey params and AWS/Twitter built-in platforms
The AWS, Twitter, and Facebook built-in platforms are being deprecated and the `AccessKeyId`/`SecretKey` connection properties marked obsolete in [PangaeaAppliance#209](https://github.com/Kevin-Andrew/PangaeaAppliance/pull/209). Flagged these in the docs so new platforms don't adopt deprecated surfaces:

- `docs/reference/reserved-parameters.md` — marked `FuncUserAccessKeyId`/`FuncUserAccessKey` deprecated + explanatory note
- `docs/reference/commands/cookies.md` / `docs/reference/commands/forms.md` — noted the cited `System/Aws.json` and `System/Twitter.json` built-ins are deprecated (shown only to illustrate command syntax)

The custom-platform samples (`CustomTwitter`, `CustomFacebook`) are intentionally **unchanged** — they demonstrate the HTTP form-fill pattern, not the deprecated built-in platforms.

## Tracking
- #72 / AB#723623 — `CreateAdminUser` removal
- #78 / AB#723622 — AWS/Twitter/Facebook deprecation

## Note
A pre-existing, unrelated line-number drift in `rsms-engine-map.md` (`Address → :133` and `AssetName → :139`, now `:134`/`:140`) was left untouched as it is outside the scope of these two issues.